### PR TITLE
Update POM: consistent groupId and remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.fit.layout.storage</groupId>
-  <artifactId>LayoutStorage</artifactId>
+  <groupId>cz.vutbr.fit.layout</groupId>
+  <artifactId>layout-storage</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>LayoutStorage</name>
   <dependencies>
@@ -27,16 +27,6 @@
 	</dependency>
 	
 	
-	<dependency>
-		<groupId>net.sf.cssbox</groupId>
-		<artifactId>cssbox</artifactId>
-		<version>4.8-SNAPSHOT</version>
-	</dependency>
-	<dependency>
-		<groupId>net.sf.cssbox</groupId>
-		<artifactId>pdf2dom</artifactId>
-		<version>1.3-SNAPSHOT</version>
-	</dependency>
 	<dependency>
 		<groupId>org.slf4j</groupId>
 		<artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
I have just updated the POM:
- changed the package identification to share the som group with the other FitLayout packages (for future distribution through maven)
- removed unnecessary (and now obsolete) CSSBox dependencies. Actually layout-cssbox should be the only package that depends on CSSBox
